### PR TITLE
fix: readme image links use full path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The pipeline has the following 5 stages:
 1. **Publish** (optional): This stage publishes the project to AWS Serverless Application Repository using the publish [app](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:077246666028:applications~aws-serverless-codepipeline-serverlessrepo-publish)
 
 Here is an example CodePipeline pipeline that has all 5 stages:
-![aws-sam-codepipeline-cd-pipeline-example](../../raw/master/images/aws-sam-codepipeline-cd-pipeline-example.png)
+![aws-sam-codepipeline-cd-pipeline-example](https://github.com/awslabs/aws-sam-codepipeline-cd/raw/master/images/aws-sam-codepipeline-cd-pipeline-example.png)
 
 ## Installation
 
@@ -25,7 +25,7 @@ Here is an example CodePipeline pipeline that has all 5 stages:
 
 General instructions for creating a GitHub OAuth token can be found [here](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/). When you get to the scopes/permissions page, you should select the "repo" and "admin:repo_hook" scopes, which will automatically select all permissions under those two scopes.
 
-![GitHub OAuth Token Permissions](../../raw/master/images/github-token-permissions.png)
+![GitHub OAuth Token Permissions](https://github.com/awslabs/aws-sam-codepipeline-cd/raw/master/images/github-token-permissions.png)
 
 ## Parameters
 

--- a/sam/app/template.yaml
+++ b/sam/app/template.yaml
@@ -5,17 +5,17 @@ Description: >-
 
 Metadata:
   AWS::ServerlessRepo::Application:
-    Name: sam-codepipeline-cd
+    Name: aws-sam-codepipeline-cd
     Description: >-
       This serverless app sets up an AWS CodePipeline Pipeline as a CD solution for a GitHub-based SAM project. Once setup, every time the specified GitHub repository branch is updated, the change will flow through the CodePipeline pipeline.
     Author: AWS Serverless Application Repository
     SpdxLicenseId: MIT-0
     Labels: [github, cd, codepipeline, continuous-deploy, sam]
     HomePageUrl: https://github.com/awslabs/aws-sam-codepipeline-cd
-    SemanticVersion: 0.1.0
-    SourceCodeUrl: https://github.com/awslabs/aws-sam-codepipeline-cd/tree/0.1.0
-    LicenseUrl: ../../../LICENSE
-    ReadmeUrl: ../../../README.md
+    SemanticVersion: 0.1.1
+    SourceCodeUrl: https://github.com/awslabs/aws-sam-codepipeline-cd/tree/0.1.1
+    LicenseUrl: ../../LICENSE
+    ReadmeUrl: ../../README.md
 
 Outputs:
   ArtifactsBucketArn:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Readme image links use full path otherwise it can't show in SAR consoles
- Fix readme and license relative path

*Tests*
`sam package`
`sam publish`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
