### PR TITLE
Support for AWS CodeCommit as a source code provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The following parameters are only applicable if `SourceCodeProvider` is CodeComm
 
 | Parameter     | Required      | Description   |
 | ------------- | ------------- | ------------- |
-| CodeCommitRepoName  | Optional  | CodeCommit repository name (just the name, not the full URL). |
+| CodeCommitRepo  | Optional  | CodeCommit repository name (just the name, not the full URL). |
 | CodeCommitBranch  | Optional  | CodeCommit repo branch name. Default: master. |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # AWS SAM CodePipeline CD ![Build Status](https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiSlYvZlpjVEttS0FjbXFyUEpvWFpwdGJtbTlSbjRTaEsranM4QjFpUWxUSTB4ZUdPeDROSlNTMW14bnRxM1l6YTRpUDZsSXg2L3hyRXpWN0ZxM1BpeGFBPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik9pWWV1MXhKbnR6alB2NTUiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 
-This serverless app sets up an AWS CodePipeline pipeline as a Continuous Deployment (CD) solution for a GitHub-based SAM project. Once setup, every time you push to the specified GitHub repository branch, the change will flow through the AWS CodePipeline pipeline.
+This serverless app sets up an AWS CodePipeline pipeline as a Continuous Deployment (CD) solution for a SAM project hosted on GitHub or AWS CodeCommit. Once setup, every time you push to the specified Git repository branch, the change will flow through the AWS CodePipeline pipeline.
 
 ## Pipeline Structure
 
 When this application is deployed, it will create an AWS CodePipeline pipeline that has up to the following 5 stages:
-1. **Source**: This stage is the entry point of the pipeline. It is triggered when you push a change to the specified GitHub respository branch.
+1. **Source**: This stage is the entry point of the pipeline. It is triggered when you push a change to the specified Git repository branch.
 1. **Build**: This stage builds the project using AWS CodeBuild.
 1. **Test** (optional): This stage runs the integration tests of the project using CodeBuild. This stage will only be created if you provide the `IntegTestRoleName` parameter when setting up this module. See the "Parameters" section below.
 1. **Deploy** (optional): This stage deploys the project using CloudFormation. This stage will only be created if you provide the `DeployRoleName` parameter when setting up this application. See the "Parameters" section below.
@@ -17,7 +17,7 @@ Here is an example CodePipeline pipeline that has all 5 stages:
 ## Installation
 
 1. [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and login
-1. Create a GitHub OAuth token (see instructions below).
+1. If your source code repository is on GitHub, then create a GitHub OAuth token (see instructions below). 
 1. Go to this app's page on the [Serverless Application Repository](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:646794253159:applications~aws-sam-codepipeline-cd) and click "Deploy"
 1. Provide the required app parameters and click "Deploy"
 
@@ -31,19 +31,34 @@ General instructions for creating a GitHub OAuth token can be found [here](https
 
 The app has the following parameters:
 
-1. `GitHubOwner` (required) - GitHub username owning the repo.
-1. `GitHubRepo` (required) - GitHub repo name (just the name, not the full URL).
-1. `GitHubOAuthToken` (required) - OAuth token used by AWS CodeBuild to connect to GitHub.
-1. `GitHubBranch` (optional) - GitHub repo branch name. Default: master
-1. `ComputeType` (optional) - AWS CodeBuild project compute type to use. See [the documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/create-project.html#create-project-cli) for details. Default: BUILD_GENERAL1_SMALL
-1. `EnvironmentType` (optional) - Environment type used by AWS CodeBuild. See [the documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/create-project.html#create-project-cli) for details. Default: LINUX_CONTAINER
-1. `BuildSpecFilePath` (optional) - CodeBuild build spec file name for build stage. See [Build Specification Reference for CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html). Default: buildspec.yaml
-1. `IntegTestRoleName` (optional) - IAM role name for test stage. This role needs to be configured to allow codebuild.amazonaws.com and cloudformation.amazonaws.com to assume it. Test stage will not be added if default value is used. Default: ''
-1. `IntegTestBuildSpecFilePath` (optional) - CodeBuild build spec file name for test stage. This parameter is only used if you provide the `IntegTestRoleName` parameter. See [the documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html). Default: integ-test-buildspec.yaml
-1. `DeployRoleName` (optional) - IAM role name for deploy stage. This role needs to be configured to allow cloudformation.amazonaws.com to assume it. Deploy stage will not be added if default value is used. Default: ''
-1. `DeployStackName` (optional) - CloudFormation stack name for deploy stage. Default: ''. This parameter is only used if you provide the `DeployRoleName` parameter. Note that if you provide the `DeployRoleName` but do not provide a `DeployStackName` then AWS CodePipeline will fail.
-1. `DeployParameterOverrides` (optional) - CloudFormation parameter overrides for deploy stage in JSON string. For more information and an example, see the `ParameterOverrides` parameter of [AWS CloudFormation Configuration Properties Reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html#w2ab1c13c13b9). Default: {}
-1. `PublishToSAR` (optional) - Boolean to indicate whether or not include publish stage. Allowed values: true, false. Default: false
+| Parameter     | Required      | Description   |
+| ------------- | ------------- | ------------- |
+| SourceCodeProvider  | Required  | Whether the Git repository is hosted on GitHub or CodeCommit. |
+| ComputeType  | Optional  | AWS CodeBuild project compute type. See [the documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/create-project.html#create-project-cli) for details. Default: BUILD_GENERAL1_SMALL |
+| EnvironmentType  | Optional  | Environment type used by AWS CodeBuild. See [the documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/create-project.html#create-project-cli) for details. Default: LINUX_CONTAINER |
+| BuildSpecFilePath  | Optional  | CodeBuild build spec file name for build stage. See [Build Specification Reference for CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html). Default: buildspec.yaml |
+| IntegTestRoleName  | Optional  | IAM role name for test stage. This role needs to be configured to allow codebuild.amazonaws.com and cloudformation.amazonaws.com to assume it. Test stage will not be added if default value is used. Default: '' |
+| IntegTestBuildSpecFilePath  | Optional  | CodeBuild build spec file name for test stage. This parameter is only used if you provide the `IntegTestRoleName` parameter. See [the documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html). Default: integ-test-buildspec.yaml |
+| DeployRoleName  | Optional  | IAM role name for deploy stage. This role needs to be configured to allow cloudformation.amazonaws.com to assume it. Deploy stage will not be added if default value is used. Default: '' |
+| DeployStackName  | Optional  | CloudFormation stack name for deploy stage. Default: ''. This parameter is only used if you provide the `DeployRoleName` parameter. Note that if you provide the `DeployRoleName` but do not provide a `DeployStackName` then AWS CodePipeline will fail. |
+| DeployParameterOverrides  | Optional  | CloudFormation parameter overrides for deploy stage in JSON string. For more information and an example, see the `ParameterOverrides` parameter of [AWS CloudFormation Configuration Properties Reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html#w2ab1c13c13b9). Default: {} |
+| PublishToSAR  | Optional  | Boolean to indicate whether or not include publish stage. Allowed values: true, false. Default: false |
+
+The following parameters are only applicable if `SourceCodeProvider` is GitHub.
+
+| Parameter     | Required      | Description   |
+| ------------- | ------------- | ------------- |
+| GitHubOwner  | Required  | GitHub username owning the repo. |
+| GitHubRepo  | Required  | GitHub repo name (just the name, not the full URL). |
+| GitHubOAuthToken  | Required  | OAuth token used by AWS CodeBuild to connect to GitHub. |
+| GitHubBranch  | Optional  | GitHub repo branch name. Default: master. |
+
+The following parameters are only applicable if `SourceCodeProvider` is CodeCommit.
+
+| Parameter     | Required      | Description   |
+| ------------- | ------------- | ------------- |
+| CodeCommitRepoName  | Required  | CodeCommit repository name (just the name, not the full URL). |
+| CodeCommitBranch  | Optional  | CodeCommit repo branch name. Default: master. |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -48,16 +48,16 @@ The following parameters are only applicable if `SourceCodeProvider` is GitHub.
 
 | Parameter     | Required      | Description   |
 | ------------- | ------------- | ------------- |
-| GitHubOwner  | Required  | GitHub username owning the repo. |
-| GitHubRepo  | Required  | GitHub repo name (just the name, not the full URL). |
-| GitHubOAuthToken  | Required  | OAuth token used by AWS CodeBuild to connect to GitHub. |
+| GitHubOwner  | Optional  | GitHub username owning the repo. |
+| GitHubRepo  | Optional  | GitHub repo name (just the name, not the full URL). |
+| GitHubOAuthToken  | Optional  | OAuth token used by AWS CodeBuild to connect to GitHub. |
 | GitHubBranch  | Optional  | GitHub repo branch name. Default: master. |
 
 The following parameters are only applicable if `SourceCodeProvider` is CodeCommit.
 
 | Parameter     | Required      | Description   |
 | ------------- | ------------- | ------------- |
-| CodeCommitRepoName  | Required  | CodeCommit repository name (just the name, not the full URL). |
+| CodeCommitRepoName  | Optional  | CodeCommit repository name (just the name, not the full URL). |
 | CodeCommitBranch  | Optional  | CodeCommit repo branch name. Default: master. |
 
 ## Outputs

--- a/sam/app/template.yaml
+++ b/sam/app/template.yaml
@@ -54,12 +54,15 @@ Parameters:
     Description: OAuth token used by AWS CodePipeline to connect to GitHub
     NoEcho: true
     Type: String
+    Default: ''
   GitHubOwner:
     Description: GitHub username owning the repo
     Type: String
+    Default: ''
   GitHubRepo:
     Description: GitHub repo name
     Type: String
+    Default: ''
   GitHubBranch:
     Description: GitHub repo branch name. It defaults to master if not specified.
     Type: String
@@ -67,6 +70,7 @@ Parameters:
   CodeCommitRepo:
     Type: String
     Description: CodeCommit repository name, only specify if you chose CodeCommit in SourceCodeProvider
+    Default: ''
   CodeCommitBranch:
     Type: String
     Description: CodeCommit repository branch name, only specify if you chose CodeCommit in SourceCodeProvider.

--- a/sam/app/template.yaml
+++ b/sam/app/template.yaml
@@ -64,7 +64,7 @@ Parameters:
     Description: GitHub repo branch name. It defaults to master if not specified.
     Type: String
     Default: master
-  CodeCommitRepoName:
+  CodeCommitRepo:
     Type: String
     Description: CodeCommit repository name, only specify if you chose CodeCommit in SourceCodeProvider
   CodeCommitBranch:
@@ -137,8 +137,8 @@ Rules:
   ValidateCodeCommit:
     RuleCondition: !Equals [!Ref SourceCodeProvider, 'CodeCommit']
     Assertions:
-      - Assert: !Not [!Equals [!Ref CodeCommitRepoName, '']]
-        AssertDescription: "CodeCommitRepoName must be specified when SourceCodeProvider is CodeCommit"
+      - Assert: !Not [!Equals [!Ref CodeCommitRepo, '']]
+        AssertDescription: "CodeCommitRepo must be specified when SourceCodeProvider is CodeCommit"
       - Assert: !Not [!Equals [!Ref CodeCommitBranch, '']]
         AssertDescription: "CodeCommitBranch must be specified when SourceCodeProvider is CodeCommit"
 
@@ -186,7 +186,7 @@ Resources:
                   Provider: CodeCommit
                   Version: "1"
                 Configuration:
-                  RepositoryName: !Ref CodeCommitRepoName
+                  RepositoryName: !Ref CodeCommitRepo
                   BranchName: !Ref CodeCommitBranch
                 OutputArtifacts:
                   - Name: SourceArtifact
@@ -385,7 +385,7 @@ Resources:
                     - "codecommit:UploadArchive"
                     - "codecommit:CancelUploadArchive"
                   Resource:
-                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${CodeCommitRepoName}
+                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${CodeCommitRepo}
           - !Ref AWS::NoValue
   BuildProject:
     Type: AWS::CodeBuild::Project

--- a/sam/app/template.yaml
+++ b/sam/app/template.yaml
@@ -122,6 +122,26 @@ Conditions:
   UseGitHub:
     !Equals [!Ref SourceCodeProvider, 'GitHub']
 
+Rules:
+  ValidateGitHub:
+    RuleCondition: !Equals [!Ref SourceCodeProvider, 'GitHub']
+    Assertions:
+      - Assert: !Not [!Equals [!Ref GitHubOwner, '']]
+        AssertDescription: "GitHubOwner must be specified when SourceCodeProvider is GitHub"
+      - Assert: !Not [!Equals [!Ref GitHubRepo, '']]
+        AssertDescription: "GitHubRepo must be specified when SourceCodeProvider is GitHub"
+      - Assert: !Not [!Equals [!Ref GitHubOAuthToken, '']]
+        AssertDescription: "GitHubOAuthToken must be specified when SourceCodeProvider is GitHub"
+      - Assert: !Not [!Equals [!Ref GitHubBranch, '']]
+        AssertDescription: "GitHubBranch must be specified when SourceCodeProvider is GitHub"
+  ValidateCodeCommit:
+    RuleCondition: !Equals [!Ref SourceCodeProvider, 'CodeCommit']
+    Assertions:
+      - Assert: !Not [!Equals [!Ref CodeCommitRepoName, '']]
+        AssertDescription: "CodeCommitRepoName must be specified when SourceCodeProvider is CodeCommit"
+      - Assert: !Not [!Equals [!Ref CodeCommitBranch, '']]
+        AssertDescription: "CodeCommitBranch must be specified when SourceCodeProvider is CodeCommit"
+
 Resources:
   Artifacts:
     Properties:

--- a/sam/app/template.yaml
+++ b/sam/app/template.yaml
@@ -43,6 +43,13 @@ Parameters:
     Default: LINUX_CONTAINER
     Description: Environment type used by AWS CodeBuild. See the documentation for details (https://docs.aws.amazon.com/codebuild/latest/userguide/create-project.html#create-project-cli).
     Type: String
+  SourceCodeProvider:
+    Type: String
+    Description: Location of your source code repository
+    Default: GitHub
+    AllowedValues:
+      - GitHub
+      - CodeCommit
   GitHubOAuthToken:
     Description: OAuth token used by AWS CodePipeline to connect to GitHub
     NoEcho: true
@@ -56,6 +63,13 @@ Parameters:
   GitHubBranch:
     Description: GitHub repo branch name. It defaults to master if not specified.
     Type: String
+    Default: master
+  CodeCommitRepoName:
+    Type: String
+    Description: CodeCommit repository name, only specify if you chose CodeCommit in SourceCodeProvider
+  CodeCommitBranch:
+    Type: String
+    Description: CodeCommit repository branch name, only specify if you chose CodeCommit in SourceCodeProvider.
     Default: master
   DeployParameterOverrides:
     Description: Parameter overrides for the deploy stage
@@ -103,6 +117,11 @@ Conditions:
     !Not [!Equals [!Ref DeployRoleName, '']]
   HasPublishStage:
     !Equals [!Ref PublishToSAR, 'true']
+  UseCodeCommit:
+    !Equals [!Ref SourceCodeProvider, 'CodeCommit']
+  UseGitHub:
+    !Equals [!Ref SourceCodeProvider, 'GitHub']
+
 Resources:
   Artifacts:
     Properties:
@@ -138,20 +157,33 @@ Resources:
       Stages:
         - Name: Source
           Actions:
-            - Name: GitHubSource
-              ActionTypeId:
-                Category: Source
-                Owner: ThirdParty
-                Provider: GitHub
-                Version: "1"
-              Configuration:
-                Owner: !Ref GitHubOwner
-                OAuthToken: !Ref GitHubOAuthToken
-                Repo: !Ref GitHubRepo
-                Branch: !Ref GitHubBranch
-                PollForSourceChanges: false
-              OutputArtifacts:
-                - Name: SourceArtifact
+            - !If
+              - UseCodeCommit
+              - Name: CodeCommitSource
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeCommit
+                  Version: "1"
+                Configuration:
+                  RepositoryName: !Ref CodeCommitRepoName
+                  BranchName: !Ref CodeCommitBranch
+                OutputArtifacts:
+                  - Name: SourceArtifact
+              - Name: GitHubSource
+                ActionTypeId:
+                  Category: Source
+                  Owner: ThirdParty
+                  Provider: GitHub
+                  Version: "1"
+                Configuration:
+                  Owner: !Ref GitHubOwner
+                  OAuthToken: !Ref GitHubOAuthToken
+                  Repo: !Ref GitHubRepo
+                  Branch: !Ref GitHubBranch
+                  PollForSourceChanges: false
+                OutputArtifacts:
+                  - Name: SourceArtifact
         - Name: Build
           Actions:
             - Name: Build
@@ -317,6 +349,24 @@ Resources:
                   Resource:
                     - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${DeployRoleName}
           - !Ref AWS::NoValue
+        - !If
+          - UseCodeCommit
+          - PolicyName: codecommit-access
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - "codecommit:ListBranches"
+                    - "codecommit:GetBranch"
+                    - "codecommit:GetCommit"
+                    - "codecommit:GetUploadArchiveStatus"
+                    - "codecommit:GitPull"
+                    - "codecommit:UploadArchive"
+                    - "codecommit:CancelUploadArchive"
+                  Resource:
+                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${CodeCommitRepoName}
+          - !Ref AWS::NoValue
   BuildProject:
     Type: AWS::CodeBuild::Project
     Properties:
@@ -335,6 +385,7 @@ Resources:
             Value: !Ref Artifacts
   GitHubWebhook:
     Type: 'AWS::CodePipeline::Webhook'
+    Condition: UseGitHub
     Properties:
       AuthenticationConfiguration:
         SecretToken: !Ref GitHubOAuthToken


### PR DESCRIPTION
**Description of changes:**
Support for AWS CodeCommit as a source code provider for the pipeline. I have also updated the README file to include CodeCommit instructions. In the process I decided to turn the parameters section into a Table for better readability, instead of a numbered list. But it's just a proposal, I can change it back to a list if you prefer. 

**Testing**
I have tested both workflows GitHub and CodeCommit work properly by launching 2 stacks in my AWS account, one for each.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
